### PR TITLE
CVE-2005-2728

### DIFF
--- a/cves/CVE-2005-2728.yml
+++ b/cves/CVE-2005-2728.yml
@@ -3,7 +3,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE: 789 - Uncontrolled Memory Allocation
+CWE: 789
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional

--- a/cves/CVE-2005-2728.yml
+++ b/cves/CVE-2005-2728.yml
@@ -3,14 +3,14 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: 789 - Uncontrolled Memory Allocation
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
@@ -31,7 +31,10 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  There is a non-limited byte-range weakness that can cause a denial of service attack. If an attacker
+  decided to fill an HTTP header with a large amount of information, then it can cause the memory consumption to increase
+  exponentially. This memory leak can eventually lead to the crash of all servers with the same resource allocation. 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -77,9 +80,14 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer:
-  code:
-  fix:
+  answer: |
+    In the fix commit, there were not tests altered, and in the commits surrounding 
+    the fix there were not any tests altered. I then searched in and around the fixed
+    code to see if there were any tests referenced, and could not find any. I went through
+    the different unit test files and could not find any tests for this file either. Using
+    this research to make the assumption that this section of the code was not unit tested.
+  code: N/A
+  fix: N/A
 
 discovered:
   question: |
@@ -96,10 +104,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer:
-  date:
-  automated:
-  google:
+  answer: |
+    The bug was found due to employees noticing large memory leaks while using the
+    APACHE modules mod_proxy and mod_rewrite to reverse proxy backend web servers. 
+    The bug was officially discovered and reported by the employee Filip Sneppe.
+  date: 2004-07-07T21:39Z
+  automated: false
+  google: false
   contest:
 
 subsystem:
@@ -109,8 +120,11 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer:
-  name:
+  answer: |
+    The vulnerability was inside core component of the apache http application.
+    Located inside of the file byterange_filter.c, which resides
+    in the http module subsystem.
+  name: httpd/modules/http/
 
 interesting_commits:
   question: |
@@ -120,8 +134,12 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-    - commit:
-      note:
+    - commit: 1be2a4f4d27ce22dee4da56dfc21021a454b4253
+      note: | 
+        This is the first pass at refactoring the C source code. The author,
+        Justin Erenkrantz, says that their C source code is a "behemoth", weighing 
+        at over 150,000 lines of code. Mr. Erenkrantz attempted to change this file
+        and its surrounding files by reorganizing and relocating functions. 
     - commit:
       note:
 
@@ -133,10 +151,12 @@ major_events:
 
     The event doesn't need to be directly related to this vulnerability, rather,
     we want to capture what the development team was dealing with at the time.
-  answer:
-  events:
-    - name:
-      date:
+  answer: | 
+    The only major event that I saw was a large scale refactoring that most of 
+    their C source code went through. 
+  events: 
+    - name: Mass refactoring of C source code
+      date: 2004-11-27T08:07Z
     - name:
       date:
 
@@ -156,22 +176,22 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
+    applies: false
     note:
   least_privilege:
-    applies:
+    applies: false
     note:
   frameworks_are_optional:
-    applies:
+    applies: false
     note:
   native_wrappers:
-    applies:
+    applies: false
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: Distrusting input applies due to the vulnerability requiring malicious input to be exploited.
   security_by_obscurity:
-    applies:
+    applies: false
     note:
   serial_killer:
     applies:
@@ -183,8 +203,8 @@ lessons:
     applies:
     note:
   yagni:
-    applies:
-    note:
+    applies: true
+    note: Yagni applies because the range limit was not set until there was a vulnerability with it. 
   complex_inputs:
     applies:
     note:
@@ -201,4 +221,10 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    In my opinion this was just a mistake of negligence. I think that the lesson
+    yagni really applies here. There were comments in the code talking about 
+    how they knew there was no range limit. So they could have just added the check
+    to make sure that there was an end to the input, however this vulnerability existed
+    due to this negligence. According to the CWE, they are mitigating it correctly, 
+    by implementing input validation.

--- a/cves/CVE-2005-2728.yml
+++ b/cves/CVE-2005-2728.yml
@@ -32,9 +32,11 @@ description_instructions: |
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
 description: |
-  There is a non-limited byte-range weakness that can cause a denial of service attack. If an attacker
-  decided to fill an HTTP header with a large amount of information, then it can cause the memory consumption to increase
-  exponentially. This memory leak can eventually lead to the crash of all servers with the same resource allocation. 
+  There is a non-limited byte-range weakness that can cause a denial of service attack. 
+  A byte-range is the buffer size of the input. If an attacker decided to fill an HTTP 
+  header with a large amount of information, then it can cause the memory consumption to 
+  increase exponentially. This memory leak can eventually lead to the crash of all servers 
+  with the same resource allocation. 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -66,7 +68,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 4
 
 unit_tested:
   question: |

--- a/cves/CVE-2005-2728.yml
+++ b/cves/CVE-2005-2728.yml
@@ -86,8 +86,8 @@ unit_tested:
     code to see if there were any tests referenced, and could not find any. I went through
     the different unit test files and could not find any tests for this file either. Using
     this research to make the assumption that this section of the code was not unit tested.
-  code: N/A
-  fix: N/A
+  code:
+  fix:
 
 discovered:
   question: |


### PR DESCRIPTION
CVE-2005-2728 - Non-limited byte-range filter which caused mass memory leaks. The CVE yml has been filled out fully (Round 1). In my previous pull request, there were merge conflicts, now there are not. 