### PR TITLE
 CVE-2005-1268

### DIFF
--- a/cves/CVE-2005-1268.yml
+++ b/cves/CVE-2005-1268.yml
@@ -67,12 +67,16 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
   - commit: d6d4ae452d2fa3555026653e7e3b7f799fcaf474
-    note:
+    note: |
+      * modules/ssl/ssl_engine_kernel.c (ssl_callback_SSLVerify_CRL): Fix
+      off-by-one.
+
+      PR: 35081
+      Submitted by: Marc Stern <mstern csc.com>
 vccs:
   - commit: 98dee1ac47cf5cb1e61c81e27c97a4f0b805d7f4
-    note:
-  - commit:
-    note:
+    note: |
+      cleanup logging of CRL, includes ridding of some malloc/frees
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -80,7 +84,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 4
 
 unit_tested:
   question: |

--- a/cves/CVE-2005-1268.yml
+++ b/cves/CVE-2005-1268.yml
@@ -140,10 +140,13 @@ interesting_commits:
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
   commits:
-    - commit:
-      note:
-    - commit:
-      note:
+    - commit: d107d7d6af0fa59166ea547a09a3925fb74e498e
+      note: |
+        Fixes a security vulnerability in mod_ssl that allows for weaker cipher
+        suites to be accidentally used
+    - commit: a8d2e9014d021f7df68f5f5a809bcf843481e9d4
+      note: |
+        Some dev accidentally set the default Apache port to 8080, this fixes it
 
 major_events:
   question: |

--- a/cves/CVE-2005-1268.yml
+++ b/cves/CVE-2005-1268.yml
@@ -58,15 +58,16 @@ bounty:
   amt:
   announced:
   url:
-reviews: []
+# based on git log --grep=reviewed 98dee1ac47cf5cb1e61c81e27c97a4f0b805d7f4..d6d4ae452d2fa3555026653e7e3b7f799fcaf474 --oneline
+reviews: [16]
 bugs: []
 repo:
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
-   - commit: d6d4ae452d2fa3555026653e7e3b7f799fcaf474
-     note:
+  - commit: d6d4ae452d2fa3555026653e7e3b7f799fcaf474
+    note:
 vccs:
   - commit: 98dee1ac47cf5cb1e61c81e27c97a4f0b805d7f4
     note:
@@ -93,9 +94,11 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer:
-  code:
-  fix:
+  answer: |
+    There are no tests for mod_ssl at all in the hierarchy, both at the VCC and
+    the fix.
+  code: false
+  fix: false
 
 discovered:
   question: |
@@ -112,7 +115,7 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer:
+  answer: No evidence was given
   date:
   automated:
   google:
@@ -126,8 +129,7 @@ subsystem:
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
   answer: |
-    Based on the commit message for d6d4ae452d2fa3555026653e7e3b7f799fcaf474,
-    which fixed the bug.
+    The relevant file is under modules/ssl, which corresponds to mod_ssl.
   name: mod_ssl
 
 interesting_commits:
@@ -219,4 +221,11 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    The mistake was a simple coding mistake made during a cleanup, the entire
+    portion of ssl_callback_SSLVerify_CRL that performs debug printing was
+    rewritten, and the developer forgot to account for the null terminator when
+    allocating size for the buffer and for when they copied the data into it.
+
+    The CWE entry only gives one mitigation, to use the correct size when
+    copying data, which is what the fix did.

--- a/cves/CVE-2005-1268.yml
+++ b/cves/CVE-2005-1268.yml
@@ -31,7 +31,25 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  The vulnerability was in http's processing of certificate revocation lists in
+  debugging mode in its SSL module (mod_ssl).
+
+  The problem is that mod_ssl allocates a buffer of N bytes, and then tells
+  BIO_Read that it can read N bytes of text into the buffer. BIO_Read returns a
+  count of how many bytes it read, and the function uses that count to append a
+  NULL character to the end of the text. However, that returned value can be up
+  to N, which when used as an index is the n+1th index, more than the buffer can
+  hold. This could lead to memory corruption, or even a segmentation fault that
+  would bring down httpd.
+
+  Before the vulnerability-contributing commit (VCC) the buffer allocated for
+  reading was of size N+1, but BIO_Read was told it could only read up to N
+  bytes, thus there was always space for the null terminator.
+
+  Some background, certificate revocation lists are used to revoke a
+  certificate in case its private key has been compromised, or the keys used to
+  sign it.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -107,8 +125,10 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer:
-  name:
+  answer: |
+    Based on the commit message for d6d4ae452d2fa3555026653e7e3b7f799fcaf474,
+    which fixed the bug.
+  name: mod_ssl
 
 interesting_commits:
   question: |

--- a/cves/CVE-2005-1268.yml
+++ b/cves/CVE-2005-1268.yml
@@ -3,21 +3,21 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: 193
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
   entry below to "true" as soon as you start. This will enable additional
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date. A good
   source for this is Chrome's Stable Release Channel
   (https://chromereleases.googleblog.com/).
   Please enter your date in YYYY-MM-DD format.
-announced: 2005-08-05T04:00Z
+announced: 2005-05-26T09:21Z
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.


### PR DESCRIPTION
Fill out details for  CVE-2005-1268, "Off-by-one error in the mod_ssl Certificate Revocation List (CRL) verification callback in Apache, when configured to use a CRL, allows remote attackers to cause a denial of service (child process crash) via a CRL that causes a buffer overflow of one null byte."