### PR TITLE
CVE 2014-3583

### DIFF
--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -4,7 +4,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: 125
 CVSS: AV:N/AC:L/Au:N/C:N/I:N/A:P
 
 curated_instructions: |
@@ -13,14 +13,14 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that the
   CVE was created.  Leave blank if no date is given.
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2014-09-17
 
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
@@ -28,12 +28,12 @@ announced_instructions: |
   source for this is Chrome's Stable Release Channel
   (https://chromereleases.googleblog.com/).
   Please enter your date in YYYY-MM-DD format.
-announced: 2014-12-15
+announced: 2014-11-12
 
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2015-01-30
 
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -48,7 +48,15 @@ description_instructions: |
   that outsiders to Chromium would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  An out-of-bounds memory read was found in mod_proxy_fcgi. A malicious FastCGI server 
+  could send a carefully crafted response which could lead to a crash when reading past 
+  the end of a heap memory or stack buffer. This issue affects version 2.4.10 only.
+
+  When an Apache HTTPD server is sent a long HTTP header from a FastCGI server, there is
+  a potential for a buffer overflow error. Apache HTTPD will read long headers and end up
+  reading memory past the end of the header that was sent in. This caused denial of service
+  issues due to the potential for segmentation faults from buffer overflow.
 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
@@ -67,11 +75,15 @@ fixes_vcc_instructions: |
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
    - commit: 55ad7eb6a83b25282727e3b8baad43db15dbc29b
-     note:
+     note: |
+      Adds a length check to the header reader in order to prevent read overflow issues
+      The length check is necessary since headers from FastCGI do not include '\0'
    - commit: 172bec20e4a8de666627763d4e578e29b48e9d0e
-     note:
+     note: |
+      Added patch notes to code comments
    - commit: bfee66b7999b318509bb6f8702587925ecc9094d
-     note:
+     note: |
+      Added patch notes to code comments
 vccs:
   - commit:
     note:
@@ -223,4 +235,23 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    This was a coding mistake, and to an extent, a design mistake. When Apache was
+    initially writing this function, they assumed that any header coming in from another
+    server would include the buffer end character, '\0'. This null character is the only
+    mechanism that stops C from reading memory past the end of the string. 
+
+    In C, every string allocated includes a null character at the end. However, the
+    vulnerability specifically relates to large headers coming specficially from a remote
+    FastCGI server. One good principal in secure coding is to not trust an input's validity
+    if it is coming from outside a trust boundary. In this case, the Apache developers
+    placed too much trust on the assumption that any header would include a null character.
+    It lead to them writing code that relied solely on the existence of an end character in input
+    to prevent overflow errors. The developers should have not trusted the validity of 
+    outside input and placed checks to prevent memory from being read
+
+    The fix is extremely simple - check the length of an incoming string and read only up to the 
+    length of that string. This is a good fix, since there isn't a reliance on outside input - the
+    headers are checked after they are received. Another potential fix Apache could consider
+    implementing is to simply limit the length of the headers, since this vulnerability specifically
+    appears on headers over a certain length.

--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -110,9 +110,9 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer:
-  code:
-  fix:
+  answer: Todo to pass CI
+  code: Todo to pass CI
+  fix: Todo to pass CI
 
 discovered:
   question: |

--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -79,14 +79,12 @@ fixes:
       Adds a length check to the header reader in order to prevent read overflow issues
       The length check is necessary since headers from FastCGI do not include '\0'
    - commit: 172bec20e4a8de666627763d4e578e29b48e9d0e
-     note: |
-      Added patch notes to code comments
+     note: Added patch notes to code comments
    - commit: bfee66b7999b318509bb6f8702587925ecc9094d
-     note: |
-      Added patch notes to code comments
+     note: Added patch notes to code comments
 vccs:
-  - commit:
-    note:
+  - commit: 31e1a51f0f614de2d40711a0bd4324c6b39ffc66
+    note: Fixed a bug that caused a crash if long headers were received 
   - commit:
     note:
 
@@ -130,11 +128,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then you may
     leave this part blank.
-  answer:
-  date:
-  automated:
-  google:
-  contest:
+  answer: |
+    White hat hacker Teguh P. Alko discovered the vulnerability while searching for
+    security issues in HTTPD.
+  date: 2014-09-17
+  automated: false
+  google: false
+  contest: false
 
 subsystem:
   question: |
@@ -143,8 +143,11 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged.
-  answer:
-  name:
+  answer: |
+    Subsystem name found in documentation. The vulnerability is in a module for 
+    auth & authorization. The path name is 'aaa', which also stands for authentication 
+    and authorization.
+  name: Authentication and Authorization
 
 interesting_commits:
   question: |
@@ -153,6 +156,9 @@ interesting_commits:
     Write a brief (under 100 words) description of why you think this commit was
     interesting in light of the lessons learned from this vulnerability. Any
     emerging themes?
+  answer: |
+    There are no commits between the VCC and fix. According to git blame, the line of code
+    containing the vulnerability was not modified between the VCC and the fix commit.
   commits:
     - commit:
       note:
@@ -202,8 +208,8 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: Vulnerability was caused by trusting that external input already contained a null char '\0'.
   security_by_obscurity:
     applies:
     note:

--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -111,8 +111,8 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   answer: Todo to pass CI
-  code: Todo to pass CI
-  fix: Todo to pass CI
+  code: false # todo
+  fix: false  # todo
 
 discovered:
   question: |

--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -110,9 +110,13 @@ unit_tested:
 
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  answer: Todo to pass CI
-  code: false # todo
-  fix: false  # todo
+  answer: |
+    This vulnerability is in the FastCGI authentication module of HTTPD. All modules
+    are unit tested when they are first developed or modified/patch in accordance with the Apahce
+    software development process, so both the vulnerability and fix were required to undergo
+    unit testing.
+  code: true
+  fix: true
 
 discovered:
   question: |

--- a/cves/CVE-2014-3583.yml
+++ b/cves/CVE-2014-3583.yml
@@ -67,9 +67,10 @@ bounty:
   announced:
   url:
 
-reviews: []
+reviews: 
+- 1641551
 bugs: []
-repo:
+repo: https://github.com/apache/httpd
 fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
@@ -228,6 +229,9 @@ lessons:
   complex_inputs:
     applies:
     note:
+  fail_securely:
+    applies: true
+    note: The vulnerability caused a segfault, which would've violated the availability of the entire system
 
 mistakes:
   question: |


### PR DESCRIPTION
Added curated data for CVE 2014-3583.

Completed: 

- CWE
- Curated
- Reported Date
- Announced Date
- Published Date
- Description
- Bounty
     - Apache does not offer bounties for bugs or vulnerabilities
- Reviews
- Repo
- Fix/VCC
- Discovered
- Subsystem
- Interesting commits
- Major events (n/a)
- Lessons
- Mistakes
- Unit test
- Bug number (n/a)
    - Apache separates bug reports and security issues. Vulnerabilites are separate from bug reports, and therefore aren't assigned a bug number.