### PR TITLE
Update CI checks to match instructions in CVE yaml

### DIFF
--- a/spec/cve_spec.rb
+++ b/spec/cve_spec.rb
@@ -36,11 +36,10 @@ describe 'CVE yml file' do
           end
         end
 
-        it 'have answers for description, unit_tested, discovered, subsystem filled out' do
+        it 'have answers for description, unit_tested, subsystem, mistakes filled out' do
           if(vuln['curated'])
             expect(vuln['description'].to_s).not_to be_empty
             expect(vuln['unit_tested']['answer'].to_s).not_to be_empty
-            expect(vuln['discovered']['answer'].to_s).not_to be_empty
             expect(vuln['subsystem']['answer'].to_s).not_to be_empty
             expect(vuln['mistakes']['answer'].to_s).not_to be_empty
           end


### PR DESCRIPTION
- Accept empty "discovered" answer field
- List out "mistakes" section as requirement on failure

The instruction from the discovered section of the CVE yaml:
"If there is no evidence as to how this vulnerability was found, then you may leave this part blank."